### PR TITLE
docs: expand project README

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,11 @@
+# Example environment configuration for the edu project
+# Copy this file to `.env` and adjust values as needed.
+
+# URL of the Ollama model server
+OLLAMA_BASE_URL=http://localhost:11434
+
+# Name of the model to request from Ollama
+LLAMA_MODEL=llama3
+
+# Optional path to a text file containing a custom system prompt for the tutor
+SYSTEM_PROMPT_PATH=backend/app/system_prompt.txt

--- a/README.md
+++ b/README.md
@@ -1,9 +1,8 @@
 # edu
 
-An experimental AI tutoring platform.  
-It combines a FastAPI backend with a lightweight
-HTML/JavaScript frontend to provide chat-based study help,
-progress tracking and simple subscription features.
+An experimental AI tutoring platform combining a FastAPI backend with a
+lightweight HTML/JavaScript frontend.  It offers chat-based study help,
+progress tracking, and simple subscription features.
 
 ## Project structure
 
@@ -14,48 +13,69 @@ Dockerfile Container recipe bundling backend and frontend
 tasks.md   Development backlog
 ```
 
-## Getting started
+## Installation
 
-### Backend
+### Requirements
+- Python 3.11+
+- [Ollama](https://github.com/ollama/ollama) running locally or remotely
+- (Optional) Docker and docker-compose
+
+### Environment variables
+These variables configure how the backend connects to the language model and
+where to read the system prompt.
+
+| Variable | Description | Default |
+|----------|-------------|---------|
+| `OLLAMA_BASE_URL` | URL of the Ollama server | `http://localhost:11434` |
+| `LLAMA_MODEL` | Model name to request | `llama3` |
+| `SYSTEM_PROMPT_PATH` | Path to a text file with a custom system prompt | *(built-in prompt)* |
+
+Create a `.env` file (or copy `.env.example`) to provide these values.
+
+## Running locally (Python)
 1. Create a virtual environment and install dependencies:
    ```bash
    pip install -r backend/requirements.txt
    ```
-2. (Optional) set environment variables for the LLM service:
-   - `OLLAMA_BASE_URL` – URL of the Ollama server.
-   - `LLAMA_MODEL` – model name to use.
-   The backend falls back to canned replies if the model is unavailable.
-3. Run the API:
+2. Start the API:
    ```bash
    uvicorn backend.app.main:app --reload
    ```
+3. Serve the frontend:
+   ```bash
+   python -m http.server 3000 -d frontend
+   ```
+   The page expects the backend at `http://localhost:8000`.
 
-### Frontend
-Serve the `frontend/` directory or open `index.html` directly in a browser:
-
-```bash
-python -m http.server 3000 -d frontend
-```
-The page expects the backend to be available at `http://localhost:8000`.
-
-### Docker
-To run the full stack in a container:
+## Running with Docker
+Build and run the combined backend/frontend image:
 ```bash
 docker build -t edu .
-docker run -p 8000:8000 -p 3000:3000 edu
+docker run --env-file .env -p 8000:8000 -p 3000:3000 edu
 ```
 
+## Running with docker-compose
+A sample `docker-compose.yml` is provided to coordinate the API, static server,
+and Ollama model.
+```bash
+docker-compose up --build
+```
+The compose file reads variables from `.env` and exposes ports 8000, 3000, and
+11434.
+
+## Deployment notes
+- Use a persistent volume for the SQLite database.
+- Ensure environment variables are set securely in production.
+- Place a reverse proxy (e.g., Nginx) in front of the services for TLS
+  termination and routing.
+- Customize the system prompt via `SYSTEM_PROMPT_PATH` to tune tutoring style.
+
 ## Running tests
-
-The backend includes a small unittest suite.  
-Execute it from the repository root:
-
+The backend includes a small unittest suite:
 ```bash
 pytest backend/tests
 ```
 
 ## Next steps
-
-See `tasks.md` for a roadmap of planned improvements and ideas for
-contributors who want to explore testing, CI, or new features.
-
+See `tasks.md` for a roadmap of planned improvements and ideas for contributors
+who want to explore testing, CI, or new features.

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: '3.9'
+services:
+  api:
+    build: .
+    command: uvicorn backend.app.main:app --host 0.0.0.0 --port 8000
+    ports:
+      - "8000:8000"
+    env_file: .env
+    volumes:
+      - ./backend:/app/backend
+      - ./frontend:/app/frontend
+    depends_on:
+      - ollama
+  frontend:
+    build: .
+    command: python3 -m http.server 3000 --directory frontend
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./frontend:/app/frontend
+    depends_on:
+      - api
+  ollama:
+    image: ollama/ollama
+    ports:
+      - "11434:11434"
+    volumes:
+      - ollama_models:/root/.ollama
+volumes:
+  ollama_models:


### PR DESCRIPTION
## Summary
- expand README with project structure, setup instructions, and test guidance

## Testing
- `pytest backend/tests` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68aa3f5844a4832f8a219fe9fe0b68c7