### PR TITLE
Fix feedback table definition in database initialization

### DIFF
--- a/backend/app/database.py
+++ b/backend/app/database.py
@@ -139,6 +139,10 @@ def init_db() -> None:
                 comments TEXT,
                 FOREIGN KEY (user_id) REFERENCES users(id),
                 FOREIGN KEY (topic_id) REFERENCES topics(id)
+            )
+            """
+        )
+
         # Create table for study plans. A plan groups multiple goals for a user
         # and includes scheduling information such as due dates and recurring
         # cadence (e.g. weekly).


### PR DESCRIPTION
## Summary
- fix missing closing lines in `feedback` table creation
- ensure study plans and linking tables initialized correctly

## Testing
- `curl -s -X POST http://localhost:8000/register -H 'Content-Type: application/json' -d '{"username":"alice","password":"secret","role":"student"}'`
- `curl -s -X POST http://localhost:8000/threads -H 'Content-Type: application/json' -d '{"user_id":2,"name":"Math Chat"}'`
- `curl -s http://localhost:8000/materials`
- `curl -s -X POST http://localhost:8000/feedback -H 'Content-Type: application/json' -d '{"user_id":2,"topic_id":2,"rating":5,"comments":"Great"}'`
- `curl -s -X POST http://localhost:8000/goals -H 'Content-Type: application/json' -d '{"user_id":2,"topic_id":2,"description":"Study algebra","target_sessions":3}'`
- `curl -s -X POST http://localhost:8000/plans -H 'Content-Type: application/json' -d '{"user_id":2,"goal_ids":[1],"due_date":"2025-09-01","recurrence":"weekly"}'`
- `curl -s -X POST http://localhost:8000/chat -H 'Content-Type: application/json' -d '{"user_id":2,"thread_id":2,"message":"Hello"}'`
- `curl -s http://localhost:8000/users/2`
- `pytest backend/tests/test_feedback.py -q` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68aa45be9d74832f82c24ca7b0e102c7