### PR TITLE
fix: remove duplicate dependency sections

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -22,14 +22,5 @@
     "jsdom": "^23.0.0",
     "vite": "^5.0.0",
     "vitest": "^0.34.0"
-    "test": "echo 'No tests specified'"
-  },
-  "dependencies": {
-    "react": "^18.2.0",
-    "react-dom": "^18.2.0"
-  },
-  "devDependencies": {
-    "@vitejs/plugin-react": "^4.0.0",
-    "vite": "^5.0.0"
   }
 }


### PR DESCRIPTION
## Summary
- deduplicate `dependencies` and `devDependencies` in the frontend's package.json to avoid install errors

## Testing
- `npm install` *(fails: 403 Forbidden fetching @testing-library/jest-dom)*
- `npm test` *(fails: vitest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa487d06b4832fba8c3bda330a3c18