### PR TITLE
Display study plans and allow material feedback

### DIFF
--- a/frontend/src/components/PlanCard.jsx
+++ b/frontend/src/components/PlanCard.jsx
@@ -1,9 +1,27 @@
 import React from 'react';
 
-const PlanCard = () => (
+/**
+ * Display a list of study plans.
+ *
+ * @param {Object[]} plans - Array of plans returned from the API.
+ * Each plan contains an id, optional due date and a list of goals
+ * with at least a `title` field.
+ */
+const PlanCard = ({ plans = [] }) => (
   <div className="card">
     <h2>Plans</h2>
-    <p>No plans yet.</p>
+    {plans.length === 0 ? (
+      <p>No plans yet.</p>
+    ) : (
+      <ul>
+        {plans.map((plan) => (
+          <li key={plan.id}>
+            {plan.goals.map((g) => g.title).join(', ')}
+            {plan.due_date ? ` - Due ${plan.due_date}` : ''}
+          </li>
+        ))}
+      </ul>
+    )}
   </div>
 );
 

--- a/frontend/src/components/Rating.jsx
+++ b/frontend/src/components/Rating.jsx
@@ -1,0 +1,22 @@
+import { useState } from 'react';
+
+export default function Rating({ onRate }) {
+  const [value, setValue] = useState(0);
+  const handleClick = (v) => {
+    setValue(v);
+    onRate(v);
+  };
+  return (
+    <span>
+      {[1, 2, 3, 4, 5].map((n) => (
+        <span
+          key={n}
+          onClick={() => handleClick(n)}
+          style={{ cursor: 'pointer', color: n <= value ? '#ffc107' : '#e4e5e9' }}
+        >
+          ★
+        </span>
+      ))}
+    </span>
+  );
+}

--- a/frontend/src/components/StudyMaterials.jsx
+++ b/frontend/src/components/StudyMaterials.jsx
@@ -1,10 +1,13 @@
 import { useEffect, useState } from 'react';
-import { fetchMaterials } from '../services/api.js';
+import { fetchMaterials, submitFeedback } from '../services/api.js';
+import { useAppContext } from '../context/AppContext.jsx';
+import Rating from './Rating.jsx';
 
 export default function StudyMaterials() {
   const [subject, setSubject] = useState('math');
   const [category, setCategory] = useState('');
   const [materials, setMaterials] = useState([]);
+  const { userId } = useAppContext();
 
   useEffect(() => {
     fetchMaterials(subject, category).then(setMaterials).catch(console.error);
@@ -24,7 +27,10 @@ export default function StudyMaterials() {
       </select>
       <ul>
         {materials.map((m) => (
-          <li key={m.id}>{m.title}</li>
+          <li key={m.id}>
+            {m.title}
+            <Rating onRate={(r) => submitFeedback({ user_id: userId, topic_id: m.id, rating: r, comments: '' })} />
+          </li>
         ))}
       </ul>
     </div>

--- a/frontend/src/pages/Dashboard.jsx
+++ b/frontend/src/pages/Dashboard.jsx
@@ -1,18 +1,21 @@
 import { useEffect, useState } from 'react';
-import { fetchDashboard, fetchGoals, fetchMaterials } from '../services/api.js';
+import { fetchDashboard, fetchGoals, fetchPlans } from '../services/api.js';
 import { useAppContext } from '../context/AppContext.jsx';
 import ThreadsTabs from '../components/ThreadsTabs.jsx';
 import StudyMaterials from '../components/StudyMaterials.jsx';
+import PlanCard from '../components/PlanCard.jsx';
 
 export default function Dashboard() {
   const { userId } = useAppContext();
   const [goals, setGoals] = useState([]);
   const [summary, setSummary] = useState(null);
+  const [plans, setPlans] = useState([]);
 
   useEffect(() => {
     if (!userId) return;
     fetchDashboard(userId).then(setSummary).catch(console.error);
     fetchGoals(userId).then(setGoals).catch(console.error);
+    fetchPlans(userId).then(setPlans).catch(console.error);
   }, [userId]);
 
   return (
@@ -20,6 +23,7 @@ export default function Dashboard() {
       <ThreadsTabs />
       <h2>Study Goals</h2>
       <ul>{goals.map((g) => (<li key={g.id}>{g.title}</li>))}</ul>
+      <PlanCard plans={plans} />
       {summary && <p>Progress: {summary.progress}%</p>}
       <StudyMaterials />
     </div>

--- a/frontend/src/services/api.js
+++ b/frontend/src/services/api.js
@@ -17,7 +17,10 @@ export const sendChatMessage = (userId, threadId, message) =>
   request('/chat', { method: 'POST', body: JSON.stringify({ userId, threadId, message }) });
 export const fetchDashboard = (userId) => request(`/dashboard/${userId}`);
 export const fetchGoals = (userId) => request(`/goals/${userId}`);
+export const fetchPlans = (userId) => request(`/plans/${userId}`);
 export const fetchMaterials = (subject, category) => {
   const path = category ? `/materials/${subject}/${category}` : `/materials/${subject}`;
   return request(path);
 };
+export const submitFeedback = (data) =>
+  request('/feedback', { method: 'POST', body: JSON.stringify(data) });


### PR DESCRIPTION
## Summary
- Show user study plans in dashboard via new PlanCard
- Enable rating of study materials and submit feedback
- Add API helpers for plans and feedback

## Testing
- `npm test` *(fails: Invalid package.json JSONParseError)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*


------
https://chatgpt.com/codex/tasks/task_e_68aa48b0115c832f8892cadaa90d897f