### PR TITLE
Fix chat response parsing

### DIFF
--- a/frontend/src/__tests__/Chat.test.jsx
+++ b/frontend/src/__tests__/Chat.test.jsx
@@ -16,7 +16,7 @@ function setup() {
 
 describe('Chat', () => {
   it('sends message and renders reply', async () => {
-    api.sendChatMessage.mockResolvedValue({ reply: 'hello back' });
+    api.sendChatMessage.mockResolvedValue({ response: 'hello back' });
     api.fetchHistory.mockResolvedValue([]);
     setup();
     const input = screen.getByRole('textbox');


### PR DESCRIPTION
## Summary
- Flatten history items into user/bot messages for display
- Parse chat responses from `response` field with `reply` fallback
- Update tests to reflect new API shape

## Testing
- `npm test` *(fails: vitest not found)*
- `npm install` *(fails: 403 Forbidden)*
- `pytest` *(fails: ModuleNotFoundError: No module named 'httpx')*

------
https://chatgpt.com/codex/tasks/task_e_68aa50ceb49c832f80e919468bc288f8