### PR TITLE
feat: add navigation tabs for dashboard and chat

### DIFF
--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -3,17 +3,21 @@ import AuthPage from './pages/AuthPage.jsx';
 import Dashboard from './pages/Dashboard.jsx';
 import Chat from './pages/Chat.jsx';
 import { AppProvider, useAppContext } from './context/AppContext.jsx';
+import PageTabs from './components/PageTabs.jsx';
 import styles from './App.module.css';
 
 function AppRoutes() {
   const { userId } = useAppContext();
   return (
-    <Routes>
-      <Route path="/login" element={<AuthPage />} />
-      <Route path="/dashboard" element={userId ? <Dashboard /> : <Navigate to="/login" />} />
-      <Route path="/chat" element={userId ? <Chat /> : <Navigate to="/login" />} />
-      <Route path="*" element={<Navigate to={userId ? '/dashboard' : '/login'} />} />
-    </Routes>
+    <>
+      {userId && <PageTabs />}
+      <Routes>
+        <Route path="/login" element={<AuthPage />} />
+        <Route path="/dashboard" element={userId ? <Dashboard /> : <Navigate to="/login" />} />
+        <Route path="/chat" element={userId ? <Chat /> : <Navigate to="/login" />} />
+        <Route path="*" element={<Navigate to={userId ? '/dashboard' : '/login'} />} />
+      </Routes>
+    </>
   );
 }
 

--- a/frontend/src/components/PageTabs.css
+++ b/frontend/src/components/PageTabs.css
@@ -1,0 +1,17 @@
+.page-tabs {
+  display: flex;
+  gap: 1rem;
+  border-bottom: 1px solid #ccc;
+  margin-bottom: 1rem;
+}
+
+.page-tabs a {
+  padding: 0.5rem 1rem;
+  text-decoration: none;
+  color: inherit;
+}
+
+.page-tabs a.active {
+  border-bottom: 2px solid currentColor;
+  font-weight: bold;
+}

--- a/frontend/src/components/PageTabs.jsx
+++ b/frontend/src/components/PageTabs.jsx
@@ -1,0 +1,15 @@
+import { NavLink } from 'react-router-dom';
+import { useAppContext } from '../context/AppContext.jsx';
+import './PageTabs.css';
+
+export default function PageTabs() {
+  const { userId } = useAppContext();
+  if (!userId) return null;
+
+  return (
+    <nav className="page-tabs">
+      <NavLink to="/dashboard" className={({ isActive }) => isActive ? 'active' : ''}>Dashboard</NavLink>
+      <NavLink to="/chat" className={({ isActive }) => isActive ? 'active' : ''}>Chat</NavLink>
+    </nav>
+  );
+}


### PR DESCRIPTION
## Summary
- introduce PageTabs component providing links to Dashboard and Chat
- integrate PageTabs into app layout to switch between views
- style tabs with simple active state

## Testing
- `npm install` *(fails: 403 Forbidden for packages)*
- `npm test` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68aa50a688d0832f81279c3d5751524a